### PR TITLE
Fix inexistend user `www-data`

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -10,6 +10,8 @@ ADD symfony.conf /etc/nginx/conf.d/
 
 RUN echo "upstream php-upstream { server php:9000; }" > /etc/nginx/conf.d/upstream.conf
 
+RUN adduser -D -g '' -G www-data www-data
+
 CMD ["nginx"]
 
 EXPOSE 80


### PR DESCRIPTION
I've experienced the bug when nginx exits with 
```bash
nginx_1 | nginx: [emerg] getpwnam("www-data") failed in /etc/nginx/nginx.conf:1
````

Looks like it is user which is not created during nginx installation.