### PR TITLE
Added: Missing php extensions, these are used by Symfony.

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -19,7 +19,9 @@ RUN apk add --update \
     php5-pdo_mysql \
     php5-mysqli \
     php5-xml \
-    php5-zlib
+    php5-zlib \
+    php5-ctype \
+    php5-dom
 
 RUN rm -rf /var/cache/apk/* && rm -rf /tmp/*
 


### PR DESCRIPTION
The following php extensions are used by Symfony:
- php5-zlib
- php5-ctype
- php5-dom

Without them when I open http://symfony.dev/, it returns 500.
