### PR TITLE
Symfony 3 compatibility changes

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -19,6 +19,8 @@ RUN apk add --update \
     php5-pdo_mysql \
     php5-mysqli \
     php5-xml \
+    php5-dom \
+    php5-ctype \
     php5-zlib
 
 RUN rm -rf /var/cache/apk/* && rm -rf /tmp/*


### PR DESCRIPTION
Without those two additional libraries `dom` and `ctype`, Symfony 3 won't run. I haven't got enough time to check how about Symfony 2. 
