### PR TITLE
adding ctype and dom extensions

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -5,7 +5,9 @@ MAINTAINER Vincent Composieux <vincent.composieux@gmail.com>
 RUN apk add --update \
     php5-fpm \
     php5-apcu \
+    php5-ctype \
     php5-curl \
+    php5-dom \
     php5-gd \
     php5-iconv \
     php5-imagick \


### PR DESCRIPTION
In order to run Symfony 3 properly it's necessary to add php5-**ctype** and php5-**dom** extensions.
