### PR TITLE
LICENSE: add file extension

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-0BSD license
+## 0BSD license
 
 Copyright (C) 2006 by Rob Landley <rob@landley.net>
 


### PR DESCRIPTION
Since this file is not hard-wrapped, the extension is needed to trigger github's soft-wrapping rendering mode. This also allows the title to be highlighted with the appropriate semantic markup (a markdown heading).