### PR TITLE
Add php7-session to Dockerfile

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --update \
     php7-zlib \
     php7-phar \
     php7-tokenizer \
+    php7-session \
     make \
     curl
 


### PR DESCRIPTION
As described in the issue #64, the session component is missing in the alpine image, but commonly used and needed in Symfony projects.