### PR TITLE
fix: use good path for log symfony4

### DIFF
--- a/elk/logstash/logstash.conf
+++ b/elk/logstash/logstash.conf
@@ -6,12 +6,12 @@ input {
   }
   file {
     type => "symfony_dev"
-    path => "/var/www/symfony/var/logs/dev.log"
+    path => "/var/www/symfony/var/log/dev.log"
     start_position => beginning
   }
   file {
     type => "symfony_prod"
-    path => "/var/www/symfony/var/logs/prod.log"
+    path => "/var/www/symfony/var/log/prod.log"
     start_position => beginning
   }
 }


### PR DESCRIPTION
# Description

D'apres la documentation en Symfony 4, le path des logs ne prend pas de s :)