### PR TITLE
Install composer in a secure way with hash validation

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.8
 LABEL maintainer="Vincent Composieux <vincent.composieux@gmail.com>"
 
 RUN apk add --update \
+    coreutils \
     php7-fpm \
     php7-apcu \
     php7-ctype \
@@ -33,7 +34,10 @@ RUN apk add --update \
     curl
 
 RUN rm -rf /var/cache/apk/* && rm -rf /tmp/* && \
-    curl --insecure https://getcomposer.org/composer.phar -o /usr/bin/composer && chmod +x /usr/bin/composer
+    echo "$(curl -sS https://composer.github.io/installer.sig) -" > composer-setup.php.sig \
+        && curl -sS https://getcomposer.org/installer | tee composer-setup.php | sha384sum -c composer-setup.php.sig \
+        && php composer-setup.php && rm composer-setup.php* \
+        && chmod +x composer.phar && mv composer.phar /usr/bin/composer
 
 ADD symfony.ini /etc/php7/conf.d/
 ADD symfony.ini /etc/php7/cli/conf.d/


### PR DESCRIPTION
Previous installation method of composer was not safe from corrupt data
and did not validate the certificate when connecting (--insecure flag on
curl).

Not sure why this `--insecure` flag was here in the first place. This is a better way to install composer! ;)