### PR TITLE
Use --no-cache flag for apk: reduce the size of images

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine:3.8
 
 MAINTAINER Vincent Composieux <vincent.composieux@gmail.com>
 
-RUN apk add --update nginx
-RUN rm -rf /var/cache/apk/* && rm -rf /tmp/*
+RUN apk add --update --no-cache nginx
 
 ADD nginx.conf /etc/nginx/
 ADD symfony.conf /etc/nginx/conf.d/

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 LABEL maintainer="Vincent Composieux <vincent.composieux@gmail.com>"
 
-RUN apk add --update \
+RUN apk add --update --no-cache \
     coreutils \
     php7-fpm \
     php7-apcu \
@@ -33,8 +33,7 @@ RUN apk add --update \
     make \
     curl
 
-RUN rm -rf /var/cache/apk/* && rm -rf /tmp/* && \
-    echo "$(curl -sS https://composer.github.io/installer.sig) -" > composer-setup.php.sig \
+RUN echo "$(curl -sS https://composer.github.io/installer.sig) -" > composer-setup.php.sig \
         && curl -sS https://getcomposer.org/installer | tee composer-setup.php | sha384sum -c composer-setup.php.sig \
         && php composer-setup.php && rm composer-setup.php* \
         && chmod +x composer.phar && mv composer.phar /usr/bin/composer


### PR DESCRIPTION
This change reduces the size of the nginx image from 7.12 MB to 5.84 MB
and the php image from 152 MB to 151 MB.