### PR TITLE
Add xmlwriter dependency to php-fpm Dockerfile

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --update --no-cache \
     php7-simplexml \
     php7-xdebug \
     php7-zip \
+    php7-xmlwriter \
     make \
     curl
 


### PR DESCRIPTION
This PR simply adds a dependency on `php7-xmlwriter` to the `php-fpm` Dockerfile.

The reasoning behind this, is that when using Symfony 4, after installing `symfony/test-pack`, running phpunit, will cause PHPUnit 6.5 to be installed, but the dependency cannot be installed, as the docker container's php does not have access to `ext-xmlwriter` and phpunit's code coverage library relies on it.