### PR TITLE
Alleviate manual XDebug config by using new Docker DNS name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ You can also use Kibana to visualize Nginx & Symfony logs by visiting `http://sy
 
 # Use xdebug!
 
-To use xdebug change the line `"docker-host.localhost:127.0.0.1"` in docker-compose.yml and replace 127.0.0.1 with your machine ip addres.
-If your IDE default port is not set to 5902 you should do that, too.
+Configure your IDE to use port 5902 for XDebug.
+Docker versions below 18.03.1 don't support the Docker variable `host.docker.internal`.  
+In that case you'd have to swap out `host.docker.internal` with your machine IP address in php-fpm/xdebug.ini.
 
 # Code license
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
             - ./logs/symfony:/var/www/symfony/var/log:cached
         links:
             - db
-        extra_hosts:
-            - "docker-host.localhost:127.0.0.1"
     nginx:
         build: ./nginx
         ports:

--- a/php-fpm/xdebug.ini
+++ b/php-fpm/xdebug.ini
@@ -3,4 +3,4 @@ zend_extension=xdebug.so
 [Xdebug]
 xdebug.remote_enable=true
 xdebug.remote_port=5902
-xdebug.remote_host=docker-host.localhost
+xdebug.remote_host=host.docker.internal


### PR DESCRIPTION
Removes the manual step of swapping out docker-host.localhost with your machine ip.