### PR TITLE
#133 Xdebug configs updated for Xdebug 3.

### DIFF
--- a/php-fpm/xdebug.ini
+++ b/php-fpm/xdebug.ini
@@ -1,6 +1,6 @@
 zend_extension=xdebug.so
 
 [Xdebug]
-xdebug.remote_enable=true
-xdebug.remote_port=5902
-xdebug.remote_host=host.docker.internal
+xdebug.mode=debug
+xdebug.client_port=5902
+xdebug.client_host=host.docker.internal


### PR DESCRIPTION
The Xdebug 2 configs replaced by Xdebug 3 configs. With these settings (and `ENABLE_PHP_XDEBUG: 1` in the `docker-compose.yml` of course) Xdebug works out of the box.